### PR TITLE
new options to dump declaration for an extension or UTI

### DIFF
--- a/duti.c
+++ b/duti.c
@@ -37,10 +37,13 @@ main( int ac, char *av[] )
     extern int		optind;
     extern char		*optarg;
 
-    while (( c = getopt( ac, av, "d:l:hsVvx:" )) != -1 ) {
+    while (( c = getopt( ac, av, "d:e:l:hsu:Vvx:" )) != -1 ) {
 	switch ( c ) {
 	case 'd':	/* show default handler for UTI */
 	    return( uti_handler_show( optarg, 0 ));
+
+	case 'e':	/* UTI declarations for extension */
+		return( duti_utis_for_extension( optarg ));
 
 	case 'h':	/* help */
 	default:
@@ -53,6 +56,9 @@ main( int ac, char *av[] )
 	case 's':	/* set handler */
 	    set = 1;
 	    break;
+
+	case 'u':	/* UTI declarations */
+		return( duti_utis( optarg ));
 
 	case 'V':	/* version */
 	    printf( "%s\n", duti_version );

--- a/handler.h
+++ b/handler.h
@@ -19,3 +19,5 @@ int		url_handler_show( char *url_scheme );
 int		duti_handler_set( char *, char *, char * );
 int		duti_default_app_for_extension( char * );
 int		duti_is_conformant_uti( CFStringRef );
+int		duti_utis( char * );
+int		duti_utis_for_extension( char * );


### PR DESCRIPTION
I've added a couple of options to duti to display the UTI declaration(s) for either an extension (-e) or UTI (-u). I hope they might be of worth to others.

The output is as follows:

```
# duti -e csv
identifier: public.comma-separated-values-text
description: comma-separated values
declaration: {
    UTTypeIdentifier = public.comma-separated-values-text
    UTTypeTagSpecification = {
        public.mime-type = [
            text/csv
            text/comma-separated-values
        ]
        public.filename-extension = [
            csv
        ]
    }
    UTTypeConformsTo = [
        public.delimited-values-text
    ]
    UTTypeReferenceURL = http://www.ietf.org/rfc/rfc4180.txt
    UTTypeDescription = comma-separated values
}
# duti -u public.delimited-values-text
description: delimited text values
declaration: {
    UTTypeDescription = delimited text values
    UTTypeConformsTo = [
        public.text
    ]
    UTTypeIdentifier = public.delimited-values-text
}
```
