### PR TITLE
emacs magic for correct tabs

### DIFF
--- a/duti.c
+++ b/duti.c
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 /* duti: set default handlers for document types based on a settings file. */
 
 #include <ApplicationServices/ApplicationServices.h>

--- a/handler.c
+++ b/handler.c
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 #include <ApplicationServices/ApplicationServices.h>
 #include <CoreFoundation/CoreFoundation.h>
 

--- a/handler.h
+++ b/handler.h
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 struct roles {
     const char		*r_role;
     LSRolesMask		r_mask;

--- a/plist.c
+++ b/plist.c
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <sys/types.h>

--- a/plist.h
+++ b/plist.h
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 int		read_plist( char *, CFDictionaryRef * );
 
 /* plist keys */

--- a/util.c
+++ b/util.c
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 #include <CoreFoundation/CoreFoundation.h>
 #include <ctype.h>
 #include <errno.h>

--- a/util.h
+++ b/util.h
@@ -1,3 +1,5 @@
+/* -*- mode:c; tab-width: 8 -*- */
+
 struct ll {
     char	*l_path;
     struct ll	*l_next;


### PR DESCRIPTION
emacs allows to use any tab size. First magic line force to use width 8
for duti source.
