### PR TITLE
Tweak for when there is no space at the beginning of line

### DIFF
--- a/duti.1
+++ b/duti.1
@@ -317,7 +317,7 @@ in the Apple Developer Documentation Archive at:
 To get a list of UTIs on your system, you can use the following command line:
 .sp
 .br
-	$(mdfind -name lsregister) -dump | grep '[[:space:]]uti:' \\
+	$(mdfind -name lsregister) -dump | grep '[[:space:]]*uti:' \\
 .br
 		| awk '{ print $2 }' | sort | uniq
 .sp


### PR DESCRIPTION
My results didn't have a space at the beginning of the line, so this tweaks the regex to work.