### PR TITLE
Add validation for dynamic UTI registration

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -50,7 +50,7 @@ AC_DEFUN([DUTI_CHECK_SDK],
 	    macosx_arches="-arch x86_64"
 	    ;;
 
-	darwin20*|darwin21*|darwin22*)
+	darwin20*|darwin21*|darwin22*|darwin23*|darwin24*|darwin25*)
 	    sdk_path="${sdk_path}/MacOSX.sdk"
 	    macosx_arches="-arch x86_64 -arch arm64"
 	    ;;
@@ -135,6 +135,18 @@ AC_DEFUN([DUTI_CHECK_DEPLOYMENT_TARGET],
 
 	darwin22*)
 	    dep_target="13"
+	    ;;
+
+	darwin23*)
+	    dep_target="14"
+	    ;;
+
+	darwin24*)
+	    dep_target="15"
+	    ;;
+
+	darwin25*)
+	    dep_target="26"
 	    ;;
 
     esac

--- a/handler.c
+++ b/handler.c
@@ -496,6 +496,26 @@ duti_handler_set( char *bid, char *type, char *role )
 		rc = 2;
 		goto duti_set_cleanup;
 	    }
+
+	    /*
+	     * If the OS could not find a registered UTI for the given
+	     * extension or MIME type it synthesises a dynamic UTI with a
+	     * "dyn." prefix.  Launch Services refuses to register a default
+	     * handler for dynamic UTIs (returning paramErr / -50), so bail
+	     * out early with a meaningful message
+	     */
+	    if ( CFStringHasPrefix( preferredUTI,
+				    CFSTR( "dyn." ))) {
+		char cdyn[ MAXPATHLEN ];
+		if ( cf2c( preferredUTI, cdyn, sizeof( cdyn )) != 0 ) {
+		    strlcpy( cdyn, "dyn.*", sizeof( cdyn ));
+		}
+		fprintf( stderr, "no registered UTI for type \"%s\" "
+				 "(resolved to dynamic UTI %s); "
+				 "cannot set handler\n", type, cdyn );
+		rc = 2;
+		goto duti_set_cleanup;
+	    }
 	}
     }
     if ( c2cf( bid, &cf_bid ) != 0 ) {


### PR DESCRIPTION
When the OS can't find a UTI for the extension, it returns a dynamic UTI in the format `dyn.<random_string>`. Example:

```
% duti -s `osascript -e 'id of app "Visual Studio Code"'` ".info" all
failed to set com.microsoft.VSCode as handler for dyn.ah62d4qmxhk2x44psq31u (error -50)
```

this PR gracefully handles this situation and returns an error message: 

```
% ./duti -s `osascript -e 'id of app "Visual Studio Code"'` ".info" all
no registered UTI for type "info" (resolved to dynamic UTI dyn.ah62d4qmxhk2x44psq31u); cannot set handler
```

The exit code is still `2`.

I've also updated aclocal.m4 so that it can build on my current version of macOS (Tahoe)